### PR TITLE
Fix for OpenSSL 1.1.0 error: Missing = in header key=value

### DIFF
--- a/hapos-upd
+++ b/hapos-upd
@@ -436,7 +436,7 @@ fi
 # query the OCSP server and save its response
 $OPENSSL_BIN ocsp -issuer $TMP/chain.pem -cert $TMP/ee.pem \
     -respout $TMP/ocsp.der -noverify \
-    -no_nonce -url $OCSP_URL -header "Host" "$OCSP_HOST" &>>$TMP/log
+    -no_nonce -url $OCSP_URL -header "Host=$OCSP_HOST" &>>$TMP/log
 
 if [ $? -ne 0 ]; then
     Error 1 "can't receive the OCSP server response"


### PR DESCRIPTION
The -header option changed syntax in OpenSSL 1.1.0. For backwards compatibility with previous versions we probably need to check the OpenSSL version somehow. Not sure how best to do that in the context of this script

more info: https://github.com/nghttp2/nghttp2/pull/743