### PR TITLE
Feature: Added support for OpenSSL -partial_chain

### DIFF
--- a/hapos-upd
+++ b/hapos-upd
@@ -30,6 +30,7 @@ OCSP_HOST=""
 VERIFY=1
 TMP=""
 SKIP_UPDATE=0
+PARTIAL_CHAIN=""
 
 function Quit() {
     if [ $KEEP_TEMP -eq 0 ]; then
@@ -140,6 +141,10 @@ Options:
                          'Host:' header; use this instead of the one
                          extracted from the OCSP server URL.
 
+     --partial-chain   : Allow partial certificate chain if at least one certificate 
+                         is in trusted store. Useful when validating an intermediate
+                         certificate without the root CA.
+                         
  -s, --socket file     : haproxy admin socket. If omitted,
                          $HAPROXY_ADMIN_SOCKET_DEFAULT is used by default.
                          This script is distributed with only one 
@@ -194,6 +199,10 @@ do
 
         --noverify)
             VERIFY=0
+            ;;
+
+        --partial-chain)
+            PARTIAL_CHAIN="-partial_chain"
             ;;
 
         -l|--syslog)
@@ -423,7 +432,7 @@ else
 fi
 
 # check if the EE certificate validates against the chain
-$OPENSSL_BIN verify -CAfile $TMP/chain.pem $TMP/ee.pem &>>$TMP/log
+$OPENSSL_BIN verify $PARTIAL_CHAIN -CAfile $TMP/chain.pem $TMP/ee.pem &>>$TMP/log
 
 if [ $? -ne 0 ]; then
     if [ -e $CERT.issuer ]; then
@@ -442,11 +451,11 @@ $OPENSSL_BIN version | grep "OpenSSL 1.0" &>/dev/null
 if [ $? -eq 0 ]; then
     # OpenSSL 1.0.x
 
-    $OPENSSL_BIN ocsp -issuer $TMP/chain.pem -cert $TMP/ee.pem \
+    $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer $TMP/chain.pem -cert $TMP/ee.pem \
         -respout $TMP/ocsp.der -noverify \
         -no_nonce -url $OCSP_URL -header "Host" "$OCSP_HOST" &>>$TMP/log
 else
-    $OPENSSL_BIN ocsp -issuer $TMP/chain.pem -cert $TMP/ee.pem \
+    $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer $TMP/chain.pem -cert $TMP/ee.pem \
         -respout $TMP/ocsp.der -noverify \
         -no_nonce -url $OCSP_URL -header "Host=$OCSP_HOST" &>>$TMP/log
 fi
@@ -461,11 +470,11 @@ if [ $VERIFY -eq 0 ]; then
     VERIFYOPT="-noverify"
 fi
 if [ -z "$VAFILE" ]; then
-    $OPENSSL_BIN ocsp $VERIFYOPT -issuer $TMP/chain.pem -cert $TMP/ee.pem \
+    $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer $TMP/chain.pem -cert $TMP/ee.pem \
         -respin $TMP/ocsp.der -no_nonce -CAfile $TMP/chain.pem \
         -out $TMP/ocsp.txt &>>$TMP/ocsp-verify.txt
 else
-    $OPENSSL_BIN ocsp $VERIFYOPT -issuer $TMP/chain.pem -cert $TMP/ee.pem \
+    $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer $TMP/chain.pem -cert $TMP/ee.pem \
         -respin $TMP/ocsp.der -no_nonce -CAfile $TMP/chain.pem \
         -VAfile $VAFILE \
         -out $TMP/ocsp.txt &>>$TMP/ocsp-verify.txt


### PR DESCRIPTION
When validating against an intermediate certificate, there is now the option to specify that you have a partial certificate chain. I've added the "-partial_chain" flag to support that.