### PR TITLE
Properly quote variable substitutions

### DIFF
--- a/.github/shellcheck.sh
+++ b/.github/shellcheck.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+sudo apt-get update
+sudo apt-get install shellcheck
+
+shellcheck -C hapos-upd

--- a/.github/test_execution.sh
+++ b/.github/test_execution.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+sudo apt-get update
+sudo apt-get install -y openssl socat ca-certificates
+
+echo "" | \
+    openssl s_client \
+        -connect github.com:443 \
+        -showcerts 2>/dev/null | \
+            sed -n -e "/-----BEGIN CERTIFICATE/,/-----END CERTIFICATE/p" > github.com.pem
+
+./hapos-upd --cert github.com.pem -d --VAfile - > output
+
+grep "Response verify OK" output

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run shellcheck
+        run: .github/shellcheck.sh
+        env:
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-execution:
+    name: Test execution
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run test execution
+        run: .github/test_execution.sh
+        env:
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/hapos-upd
+++ b/hapos-upd
@@ -74,9 +74,9 @@ function Error() {
 
 function Debug() {
     if [ $DEBUG -eq 1 ]; then
-        echo "$1"
+        echo "${@}"
     fi
-    echo "$1" >>"${TMP}"/log
+    echo "${@}" >>"${TMP}"/log
 }
 
 function Trap() {

--- a/hapos-upd
+++ b/hapos-upd
@@ -39,6 +39,7 @@ function Quit() {
             rm -r "${TMP}" &>/dev/null
         fi
     fi
+    # shellcheck disable=SC2086
     exit ${err}
 }
 
@@ -57,6 +58,7 @@ function LogError() {
 function Error() {
     local -i err=$1
 
+    # shellcheck disable=SC2086
     if [ ${err} -eq 9 ]; then
         MSG="Error: $2"
     else
@@ -65,10 +67,12 @@ function Error() {
 
     LogError "$MSG"
 
+    # shellcheck disable=SC2086
     if [ ${err} -eq 9 ]; then
         echo "Run $PROGNAME -h for help" >&2
     fi
 
+    # shellcheck disable=SC2086
     Quit ${err}
 }
 

--- a/hapos-upd
+++ b/hapos-upd
@@ -24,6 +24,7 @@ HAPROXY_ADMIN_SOCKET="$HAPROXY_ADMIN_SOCKET_DEFAULT"
 GOOD_ONLY=0
 SYSLOG_PRIO=""
 typeset -i DEBUG=0
+typeset -i NUM_OF_CERTS
 KEEP_TEMP=0
 OCSP_URL=""
 OCSP_HOST=""
@@ -402,6 +403,7 @@ else
     # get number of certificates in the bundle file
     NUM_OF_CERTS=$(cat "${CERT}" | grep -ce "$PEM_BEGIN_CERT")
 
+    # shellcheck disable=SC2086
     if [ $NUM_OF_CERTS -le 1 ]; then
         Error 3 "can't obtain the number of certificates in the chain"
     fi
@@ -419,6 +421,7 @@ else
 
     # for each certificate that is extracted from the bundle check if 
     # it's the EE certificate, otherwise uses it to build the chain file
+    # shellcheck disable=SC2086
     for c in $(seq 1 $NUM_OF_CERTS);
     do
         # check fingerprint of current and EE certificates

--- a/hapos-upd
+++ b/hapos-upd
@@ -250,11 +250,11 @@ do
                 Error 9 "mandatory value is missing for $1 argument"
             fi
             VAFILE="$2"
-            if [ "$VAFILE" == "-" ]; then
+            if [ "${VAFILE}" == "-" ]; then
                 VAFILE="${TMP}/chain.pem"
             else
-                if [ ! -e "$VAFILE" ]; then
-                    Error 9 "VAfile does not exists: $VAFILE"
+                if [ ! -e "${VAFILE}" ]; then
+                    Error 9 "VAfile does not exists: ${VAFILE}"
                 fi
             fi
             shift
@@ -486,14 +486,14 @@ VERIFYOPT=""
 if [ $VERIFY -eq 0 ]; then
     VERIFYOPT="-noverify"
 fi
-if [ -z "$VAFILE" ]; then
+if [ -z "${VAFILE}" ]; then
     $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
         -respin "${TMP}"/ocsp.der -no_nonce -CAfile "${TMP}"/chain.pem \
         -out "${TMP}"/ocsp.txt &>>"${TMP}"/ocsp-verify.txt
 else
     $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
         -respin "${TMP}"/ocsp.der -no_nonce -CAfile "${TMP}"/chain.pem \
-        -VAfile $VAFILE \
+        -VAfile "${VAFILE}" \
         -out "${TMP}"/ocsp.txt &>>"${TMP}"/ocsp-verify.txt
 fi
 

--- a/hapos-upd
+++ b/hapos-upd
@@ -460,18 +460,15 @@ VERIFYOPT=""
 if [ $VERIFY -eq 0 ]; then
     VERIFYOPT="-noverify"
 fi
-if [ -z "${VAFILE}" ]; then
-    $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
-        -respin "${TMP}"/ocsp.der -no_nonce -CAfile "${TMP}"/chain.pem \
-        -out "${TMP}"/ocsp.txt &>>"${TMP}"/ocsp-verify.txt
-else
-    $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
-        -respin "${TMP}"/ocsp.der -no_nonce -CAfile "${TMP}"/chain.pem \
-        -VAfile "${VAFILE}" \
-        -out "${TMP}"/ocsp.txt &>>"${TMP}"/ocsp-verify.txt
+typeset -a vaarg=()
+if [[ -n "${VAFILE}" ]] ; then
+    vaarg=(-VAfile "${VAFILE}")
 fi
 
-if [ $? -ne 0 ]; then
+if ! $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer "${TMP}"/chain.pem \
+     -cert "${TMP}"/ee.pem -respin "${TMP}"/ocsp.der -no_nonce \
+     -CAfile "${TMP}"/chain.pem "${vaarg[@]}" \
+     -out "${TMP}"/ocsp.txt &>>"${TMP}"/ocsp-verify.txt ; then
     Error 1 "can't receive OCSP response"
 fi
 

--- a/hapos-upd
+++ b/hapos-upd
@@ -23,7 +23,7 @@ HAPROXY_ADMIN_SOCKET_DEFAULT="/run/haproxy/admin.sock"
 HAPROXY_ADMIN_SOCKET="$HAPROXY_ADMIN_SOCKET_DEFAULT"
 GOOD_ONLY=0
 SYSLOG_PRIO=""
-DEBUG=0
+typeset -i DEBUG=0
 KEEP_TEMP=0
 OCSP_URL=""
 OCSP_HOST=""
@@ -73,7 +73,7 @@ function Error() {
 }
 
 function Debug() {
-    if [ $DEBUG -eq 1 ]; then
+    if [ ${DEBUG} -eq 1 ]; then
         echo "${@}"
     fi
     echo "${@}" >>"${TMP}"/log
@@ -530,7 +530,7 @@ fi
 #   - the OCSP response has been verified against the chain or 
 #       the --VAfile
 
-if [ $DEBUG -eq 0 ]; then
+if [ ${DEBUG} -eq 0 ]; then
     # update .ocsp and .issuer files
 
     cp "${TMP}"/ocsp.der "${CERT}".ocsp &>>"${TMP}"/log

--- a/hapos-upd
+++ b/hapos-upd
@@ -311,7 +311,7 @@ if [ -e "${CERT}".ocsp ]; then
             Error 3 "can't parse Next Update from current OCSP response"
         fi
 
-        if [ "${CURR_EXP_EPOCH}" -lt $(date +%s) ]; then
+        if [ "${CURR_EXP_EPOCH}" -lt "$(date +%s)" ]; then
             Debug "Current OCSP response expiration: ${CURR_EXP} - expired"
             LogError "current OCSP response is expired: please consider running this script more frequently"
         else

--- a/hapos-upd
+++ b/hapos-upd
@@ -281,15 +281,11 @@ done
 
 Debug "Temporary directory: ${TMP}"
 
-$OPENSSL_BIN version | grep OpenSSL &>>"${TMP}"/log
-
-if [ $? -ne 0 ]; then
+if ! $OPENSSL_BIN version | grep OpenSSL &>>"${TMP}"/log ; then
     Error 9 "openssl binary not found; adjust OPENSSL_BIN variable in the script"
 fi
 
-$SOCAT_BIN -V | grep socat &>>"${TMP}"/log
-
-if [ $? -ne 0 ]; then
+if ! $SOCAT_BIN -V | grep socat &>>"${TMP}"/log ; then
     Error 9 "socat binary not found; adjust SOCAT_BIN variable in the script"
 fi
 
@@ -305,14 +301,10 @@ if [ -e "${CERT}".ocsp ]; then
     ISNEW=0
     Debug "An OCSP response already exists: checking its expiration."
 
-    $OPENSSL_BIN ocsp -respin "${CERT}".ocsp -text -noverify | \
-        grep "Next Update:" &>>"${TMP}"/log
-
-    if [ $? -eq 0 ]; then
+    if $OPENSSL_BIN ocsp -respin "${CERT}".ocsp -text -noverify | \
+            grep "Next Update:" &>>"${TMP}"/log ; then
         CURR_EXP=$($OPENSSL_BIN ocsp -respin "${CERT}".ocsp -text -noverify | grep "Next Update:" | cut -d ':' -f 2-)
-        CURR_EXP_EPOCH=$(date --date="${CURR_EXP}" +%s)
-
-        if [ $? -ne 0 ]; then
+        if ! CURR_EXP_EPOCH=$(date --date="${CURR_EXP}" +%s) ; then
             Error 3 "can't parse Next Update from current OCSP response"
         fi
 
@@ -329,17 +321,13 @@ fi
 # ----------------------------------
 
 # extract EE certificate
-$OPENSSL_BIN x509 -in "${CERT}" -outform PEM -out "${TMP}"/ee.pem &>>"${TMP}"/log
-
-if [ $? -ne 0 ]; then
+if ! $OPENSSL_BIN x509 -in "${CERT}" -outform PEM -out "${TMP}"/ee.pem &>>"${TMP}"/log ; then
     Error 1 "can't extract EE certificate from ${CERT}"
 fi
 
 # get OCSP server URL
 if [ -z "${OCSP_URL}" ]; then
-    OCSP_URL="$($OPENSSL_BIN x509 -in "${TMP}"/ee.pem -ocsp_uri -noout)"
-
-    if [ $? -ne 0 ]; then
+    if ! OCSP_URL="$($OPENSSL_BIN x509 -in "${TMP}"/ee.pem -ocsp_uri -noout)" ; then
         Error 1 "can't obtain OCSP server URL from ${CERT}"
     fi
 
@@ -353,17 +341,13 @@ else
 fi
 
 # check OCSP server URL format (http:// or https://)
-echo "${OCSP_URL}" | egrep -i "(http://|https://)" &>/dev/null
-
-if [ $? -ne 0 ]; then
+if ! echo "${OCSP_URL}" | egrep -i "(http://|https://)" &>/dev/null ; then
     Error 3 "OCSP server URL not in http[s]:// format"
 fi
 
 # get OCSP server URL host name
 if [ -z "$OCSP_HOST" ]; then
-    OCSP_HOST="$(echo "${OCSP_URL}" | egrep -i "(http://|https://)" | cut -d'/' -f 3)"
-
-    if [ $? -ne 0 ] || [ -z "$OCSP_HOST" ]; then
+    if ! OCSP_HOST="$(echo "${OCSP_URL}" | egrep -i "(http://|https://)" | cut -d'/' -f 3)" ; then
         Error 3 "can't extract hostname from OCSP server URL ${OCSP_URL}"
     fi
 
@@ -379,18 +363,15 @@ if [ -e "${CERT}".issuer ]; then
     Debug "Using existing chain (${CERT}.issuer)"
 
     # copy .issuer file to temporary chain.pem
-    cp "${CERT}".issuer "${TMP}"/chain.pem &>>"${TMP}"/log
-
-    if [ $? -ne 0 ]; then
+    if ! cp "${CERT}".issuer "${TMP}"/chain.pem &>>"${TMP}"/log ; then
         Error 3 "can't copy current chain from ${CERT}.issuer"
     fi
 else
     Debug "Extracting chain from certificates bundle"
 
     # get EE certificate's fingerprint
-    FP_EE="$($OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/ee.pem)"
-
-    if [ $? -ne 0 ] || [ -z "$FP_EE" ]; then
+    if ! FP_EE="$($OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/ee.pem)" ||
+	    [ -z "$FP_EE" ]; then
         Error 1 "can't obtain EE certificate's fingerprint"
     fi
 
@@ -410,12 +391,9 @@ else
 
     Debug "$NUM_OF_CERTS certificates found in the bundle"
 
-    # save each certificate in the bundle into "${TMP}"/chain-X.pem 
-    cat "${CERT}" | \
-        sed -n -e "/$PEM_BEGIN_CERT/,/$PEM_END_CERT/p" | \
-        awk "/$PEM_BEGIN_CERT/{x=\"${TMP}/chain-\" ++i \".pem\";}{print > x;}" &>>"${TMP}"/log
-
-    if [ $? -ne 0 ]; then
+    # save each certificate in the bundle into "${TMP}"/chain-X.pem
+    if ! sed <"${CERT}" -n -e "/$PEM_BEGIN_CERT/,/$PEM_END_CERT/p" | \
+            awk "/$PEM_BEGIN_CERT/{x=\"${TMP}/chain-\" ++i \".pem\";}{print > x;}" &>>"${TMP}"/log ; then
         Error 3 "can't extract certificates from bundle"
     fi
 
@@ -425,8 +403,8 @@ else
     for c in $(seq 1 $NUM_OF_CERTS);
     do
         # check fingerprint of current and EE certificates
-        FP=$($OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/chain-"${c}".pem)
-        if [ $? -ne 0 ] || [ -z "$FP" ]; then
+        if ! FP=$($OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/chain-"${c}".pem) ||
+		[ -z "$FP" ]; then
             Error 1 "can't obtain the fingerprint of the certificate n. ${c} in the bundle"
         else
             if [ ! "$FP" == "$FP_EE" ]; then
@@ -442,9 +420,7 @@ else
 fi
 
 # check if the EE certificate validates against the chain
-$OPENSSL_BIN verify $PARTIAL_CHAIN -CAfile "${TMP}"/chain.pem "${TMP}"/ee.pem &>>"${TMP}"/log
-
-if [ $? -ne 0 ]; then
+if ! $OPENSSL_BIN verify $PARTIAL_CHAIN -CAfile "${TMP}"/chain.pem "${TMP}"/ee.pem &>>"${TMP}"/log ; then
     if [ -e "${CERT}".issuer ]; then
         Error 1 "can't validate the EE certificate against the existing chain; if it has been changed recently consider removing the current ${CERT}.issuer file and let this script to figure out a new one"
     else
@@ -504,12 +480,10 @@ fi
 if [ $VERIFY -eq 1 ]; then
     Debug "OCSP response verification results: $(cat "${TMP}"/ocsp-verify.txt)"
 
-    cat "${TMP}"/ocsp-verify.txt | grep "Response verify OK" &>>"${TMP}"/log
-
-    if [ $? -ne 0 ]; then
-        grep "signer certificate not found" "${TMP}"/ocsp-verify.txt &>/dev/null
-
-        if [ $? -eq 0 ]; then
+    if ! cat "${TMP}"/ocsp-verify.txt |
+            grep "Response verify OK" &>>"${TMP}"/log ; then
+        if grep "signer certificate not found" \
+                "${TMP}"/ocsp-verify.txt &>/dev/null ; then
             Error 4 "OCSP response verification failure: signer certificate not found; try with '--VAfile -' or '--VAfile OCSP-response-signing-certificate-file' arguments"
         else
             Error 4 "OCSP response verification failure."
@@ -520,9 +494,7 @@ fi
 Debug "OCSP response: $(cat "${TMP}"/ocsp.txt)"
 
 if [ $GOOD_ONLY -eq 1 ]; then
-    cat "${TMP}"/ocsp.txt | head -n 1 | grep ": good" &>>"${TMP}"/log
-
-    if [ $? -ne 0 ]; then
+    if ! cat "${TMP}"/ocsp.txt | head -n 1 | grep ": good" &>>"${TMP}"/log ; then
         Error 4 "OCSP response, certificate status not good"
     fi
 fi
@@ -540,16 +512,12 @@ fi
 if [ ${DEBUG} -eq 0 ]; then
     # update .ocsp and .issuer files
 
-    cp "${TMP}"/ocsp.der "${CERT}".ocsp &>>"${TMP}"/log
-
-    if [ $? -ne 0 ]; then
+    if ! cp "${TMP}"/ocsp.der "${CERT}".ocsp &>>"${TMP}"/log ; then
         Error 5 "can't update ${CERT}.ocsp file"
     fi
 
     if [ ! -e "${CERT}".issuer ]; then
-        cp "${TMP}"/chain.pem "${CERT}".issuer &>>"${TMP}"/log
-
-        if [ $? -ne 0 ]; then
+        if ! cp "${TMP}"/chain.pem "${CERT}".issuer &>>"${TMP}"/log ; then
             Error 5 "can't update ${CERT}.issuer file"
         fi
     fi
@@ -559,18 +527,15 @@ if [ ${DEBUG} -eq 0 ]; then
             # no .ocsp file found, maybe it's an initial run
             Debug "Reloading haproxy."
 
-            service haproxy reload
-
-            if [ $? -ne 0 ]; then
+            if ! service haproxy reload ; then
                 Error 5 "can't reload haproxy with 'service haproxy reload'"
             fi
         else
             # update haproxy via local UNIX socket
             Debug "Updating haproxy."
 
-            echo "set ssl ocsp-response $(base64 -w 0 "${TMP}"/ocsp.der)" | $SOCAT_BIN stdio "${HAPROXY_ADMIN_SOCKET}" &>>"${TMP}"/log
-
-            if [ $? -ne 0 ]; then
+            if ! echo "set ssl ocsp-response $(base64 -w 0 "${TMP}"/ocsp.der)" |
+		    $SOCAT_BIN stdio "${HAPROXY_ADMIN_SOCKET}" &>>"${TMP}"/log ; then
                 Error 5 "can't update haproxy ssl ocsp-response using ${HAPROXY_ADMIN_SOCKET} socket"
             fi
         fi

--- a/hapos-upd
+++ b/hapos-upd
@@ -328,24 +328,24 @@ if [ $? -ne 0 ]; then
 fi
 
 # get OCSP server URL
-if [ -z "$OCSP_URL" ]; then
+if [ -z "${OCSP_URL}" ]; then
     OCSP_URL="`$OPENSSL_BIN x509 -in "${TMP}"/ee.pem -ocsp_uri -noout`"
 
     if [ $? -ne 0 ]; then
         Error 1 "can't obtain OCSP server URL from $CERT"
     fi
 
-    if [ -z "$OCSP_URL" ]; then
+    if [ -z "${OCSP_URL}" ]; then
         Error 2 "OCSP server URL not found in the EE certificate"
     fi
 
-    Debug "OCSP server URL found: $OCSP_URL"
+    Debug "OCSP server URL found: ${OCSP_URL}"
 else
-    Debug "Using OCSP server URL from command line: $OCSP_URL"
+    Debug "Using OCSP server URL from command line: ${OCSP_URL}"
 fi
 
 # check OCSP server URL format (http:// or https://)
-echo "$OCSP_URL" | egrep -i "(http://|https://)" &>/dev/null
+echo "${OCSP_URL}" | egrep -i "(http://|https://)" &>/dev/null
 
 if [ $? -ne 0 ]; then
     Error 3 "OCSP server URL not in http[s]:// format"
@@ -353,10 +353,10 @@ fi
 
 # get OCSP server URL host name
 if [ -z "$OCSP_HOST" ]; then
-    OCSP_HOST="`echo "$OCSP_URL" | egrep -i "(http://|https://)" | cut -d'/' -f 3`"
+    OCSP_HOST="`echo "${OCSP_URL}" | egrep -i "(http://|https://)" | cut -d'/' -f 3`"
 
     if [ $? -ne 0 -o -z "$OCSP_HOST" ]; then
-        Error 3 "can't extract hostname from OCSP server URL $OCSP_URL"
+        Error 3 "can't extract hostname from OCSP server URL ${OCSP_URL}"
     fi
 
     Debug "OCSP server hostname: $OCSP_HOST"
@@ -453,17 +453,17 @@ case $OPENSSL_VERSION in
         '0.9')
                 $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
                         -respout "${TMP}"/ocsp.der -noverify \
-                        -no_nonce -url $OCSP_URL -header "Host=$OCSP_HOST" &>>"${TMP}"/log
+                        -no_nonce -url "${OCSP_URL}" -header "Host=$OCSP_HOST" &>>"${TMP}"/log
                 ;;
         '1.0')
                 $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
                         -respout "${TMP}"/ocsp.der -noverify \
-                        -no_nonce -url $OCSP_URL -header "Host" "$OCSP_HOST" &>>"${TMP}"/log
+                        -no_nonce -url "${OCSP_URL}" -header "Host" "$OCSP_HOST" &>>"${TMP}"/log
                 ;;
         *)
                 $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
                         -respout "${TMP}"/ocsp.der -noverify \
-                        -no_nonce -url $OCSP_URL &>>"${TMP}"/log
+                        -no_nonce -url "${OCSP_URL}" &>>"${TMP}"/log
                 ;;
 esac
 

--- a/hapos-upd
+++ b/hapos-upd
@@ -35,13 +35,12 @@ PARTIAL_CHAIN=""
 
 function Quit() {
     local -i err=$1
-    if [ $KEEP_TEMP -eq 0 ]; then
+    if [ "$KEEP_TEMP" -eq 0 ]; then
         if [ -n "${TMP}" ]; then
             rm -r "${TMP}" &>/dev/null
         fi
     fi
-    # shellcheck disable=SC2086
-    exit ${err}
+    exit "${err}"
 }
 
 function LogError() {
@@ -59,8 +58,7 @@ function LogError() {
 function Error() {
     local -i err=$1
 
-    # shellcheck disable=SC2086
-    if [ ${err} -eq 9 ]; then
+    if [ "${err}" -eq 9 ]; then
         MSG="Error: $2"
     else
         MSG="Error processing '${CERT}': $2"
@@ -68,13 +66,11 @@ function Error() {
 
     LogError "$MSG"
 
-    # shellcheck disable=SC2086
-    if [ ${err} -eq 9 ]; then
+    if [ "${err}" -eq 9 ]; then
         echo "Run $PROGNAME -h for help" >&2
     fi
 
-    # shellcheck disable=SC2086
-    Quit ${err}
+    Quit "${err}"
 }
 
 function Debug() {
@@ -179,7 +175,7 @@ Options:
 
 trap Trap INT TERM
 
-TMP="$(mktemp -d -q -t $PROGNAME.XXXXXXXXXX)"
+TMP="$(mktemp -d -q -t "$PROGNAME.XXXXXXXXXX")"
 
 # COMMAND LINE PROCESSING
 # ----------------------------------
@@ -384,8 +380,7 @@ else
     # get number of certificates in the bundle file
     NUM_OF_CERTS=$(grep -ce "$PEM_BEGIN_CERT" < "${CERT}")
 
-    # shellcheck disable=SC2086
-    if [ $NUM_OF_CERTS -le 1 ]; then
+    if [ "$NUM_OF_CERTS" -le 1 ]; then
         Error 3 "can't obtain the number of certificates in the chain"
     fi
 
@@ -399,8 +394,7 @@ else
 
     # for each certificate that is extracted from the bundle check if 
     # it's the EE certificate, otherwise uses it to build the chain file
-    # shellcheck disable=SC2086
-    for c in $(seq 1 $NUM_OF_CERTS);
+    for c in $(seq 1 "$NUM_OF_CERTS");
     do
         # check fingerprint of current and EE certificates
         if ! FP=$($OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/chain-"${c}".pem) ||
@@ -457,7 +451,7 @@ fi
 
 # process the OCSP response
 VERIFYOPT=""
-if [ $VERIFY -eq 0 ]; then
+if [ "$VERIFY" -eq 0 ]; then
     VERIFYOPT="-noverify"
 fi
 typeset -a vaarg=()
@@ -472,7 +466,7 @@ if ! $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer "${TMP}"/chain.pem \
     Error 1 "can't receive OCSP response"
 fi
 
-if [ $VERIFY -eq 1 ]; then
+if [ "$VERIFY" -eq 1 ]; then
     Debug "OCSP response verification results: $(cat "${TMP}"/ocsp-verify.txt)"
 
     if ! grep < "${TMP}"/ocsp-verify.txt "Response verify OK" &>>"${TMP}"/log ; then
@@ -487,7 +481,7 @@ fi
 
 Debug "OCSP response: $(cat "${TMP}"/ocsp.txt)"
 
-if [ $GOOD_ONLY -eq 1 ]; then
+if [ "$GOOD_ONLY" -eq 1 ]; then
     if ! head -n 1 "${TMP}"/ocsp.txt | grep ": good" &>>"${TMP}"/log ; then
         Error 4 "OCSP response, certificate status not good"
     fi
@@ -503,7 +497,7 @@ fi
 #   - the OCSP response has been verified against the chain or 
 #       the --VAfile
 
-if [ ${DEBUG} -eq 0 ]; then
+if [ "${DEBUG}" -eq 0 ]; then
     # update .ocsp and .issuer files
 
     if ! cp "${TMP}"/ocsp.der "${CERT}".ocsp &>>"${TMP}"/log ; then
@@ -516,8 +510,8 @@ if [ ${DEBUG} -eq 0 ]; then
         fi
     fi
 
-    if [ $SKIP_UPDATE -eq 0 ]; then
-        if [ $ISNEW -eq 1 ]; then
+    if [ "$SKIP_UPDATE" -eq 0 ]; then
+        if [ "$ISNEW" -eq 1 ]; then
             # no .ocsp file found, maybe it's an initial run
             Debug "Reloading haproxy."
 

--- a/hapos-upd
+++ b/hapos-upd
@@ -358,7 +358,7 @@ fi
 if [ -z "$OCSP_HOST" ]; then
     OCSP_HOST="`echo "${OCSP_URL}" | egrep -i "(http://|https://)" | cut -d'/' -f 3`"
 
-    if [ $? -ne 0 -o -z "$OCSP_HOST" ]; then
+    if [ $? -ne 0 ] || [ -z "$OCSP_HOST" ]; then
         Error 3 "can't extract hostname from OCSP server URL ${OCSP_URL}"
     fi
 
@@ -385,7 +385,7 @@ else
     # get EE certificate's fingerprint
     FP_EE="`$OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/ee.pem`"
 
-    if [ $? -ne 0 -o -z "$FP_EE" ]; then
+    if [ $? -ne 0 ] || [ -z "$FP_EE" ]; then
         Error 1 "can't obtain EE certificate's fingerprint"
     fi
 
@@ -419,7 +419,7 @@ else
     do
         # check fingerprint of current and EE certificates
         FP=`$OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/chain-"${c}".pem`
-        if [ $? -ne 0 -o -z "$FP" ]; then
+        if [ $? -ne 0 ] || [ -z "$FP" ]; then
             Error 1 "can't obtain the fingerprint of the certificate n. ${c} in the bundle"
         else
             if [ ! "$FP" == "$FP_EE" ]; then

--- a/hapos-upd
+++ b/hapos-upd
@@ -435,25 +435,23 @@ fi
 
 OPENSSL_VERSION=$($OPENSSL_BIN version | sed -rn 's/^OpenSSL\s([0-9]\.[0-9]).*/\1/p')
 
+typeset -a hdr
 case $OPENSSL_VERSION in
-        '0.9')
-                $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
-                        -respout "${TMP}"/ocsp.der -noverify \
-                        -no_nonce -url "${OCSP_URL}" -header "Host=$OCSP_HOST" &>>"${TMP}"/log
-                ;;
-        '1.0')
-                $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
-                        -respout "${TMP}"/ocsp.der -noverify \
-                        -no_nonce -url "${OCSP_URL}" -header "Host" "$OCSP_HOST" &>>"${TMP}"/log
-                ;;
-        *)
-                $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
-                        -respout "${TMP}"/ocsp.der -noverify \
-                        -no_nonce -url "${OCSP_URL}" &>>"${TMP}"/log
-                ;;
+    '0.9')
+        hdr=(-header "Host=$OCSP_HOST")
+        ;;
+    '1.0')
+        hdr=(-header "Host" "$OCSP_HOST")
+        ;;
+    *)
+        hdr=()
+        ;;
 esac
 
-if [ $? -ne 0 ]; then
+if ! $OPENSSL_BIN ocsp $PARTIAL_CHAIN \
+     -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
+     -respout "${TMP}"/ocsp.der -noverify \
+     -no_nonce -url "${OCSP_URL}" "${hdr[@]}" &>>"${TMP}"/log ; then
     Error 1 "can't receive the OCSP server response"
 fi
 

--- a/hapos-upd
+++ b/hapos-upd
@@ -418,17 +418,17 @@ else
     for c in `seq 1 $NUM_OF_CERTS`;
     do
         # check fingerprint of current and EE certificates
-        FP="`$OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/chain-$c.pem`"
+        FP=`$OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/chain-"${c}".pem`
         if [ $? -ne 0 -o -z "$FP" ]; then
-            Error 1 "can't obtain the fingerprint of the certificate n. $c in the bundle"
+            Error 1 "can't obtain the fingerprint of the certificate n. ${c} in the bundle"
         else
             if [ ! "$FP" == "$FP_EE" ]; then
-                Debug "Bundle certificate n. $c fingerprint: $FP - it's part of the chain"
+                Debug "Bundle certificate n. ${c} fingerprint: $FP - it's part of the chain"
 
                 # current certificate is not the same as the EE; append to the chain
-                cat "${TMP}"/chain-$c.pem >> "${TMP}"/chain.pem
+                cat "${TMP}"/chain-"${c}".pem >> "${TMP}"/chain.pem
             else
-                Debug "Bundle certificate n. $c fingerprint: $FP - EE certificate"
+                Debug "Bundle certificate n. ${c} fingerprint: $FP - EE certificate"
             fi
         fi
     done

--- a/hapos-upd
+++ b/hapos-upd
@@ -174,7 +174,7 @@ Options:
 
 trap Trap INT TERM
 
-TMP="`mktemp -d -q -t $PROGNAME.XXXXXXXXXX`"
+TMP="$(mktemp -d -q -t $PROGNAME.XXXXXXXXXX)"
 
 # COMMAND LINE PROCESSING
 # ----------------------------------
@@ -304,14 +304,14 @@ if [ -e "${CERT}".ocsp ]; then
         grep "Next Update:" &>>"${TMP}"/log
 
     if [ $? -eq 0 ]; then
-        CURR_EXP=`$OPENSSL_BIN ocsp -respin "${CERT}".ocsp -text -noverify | grep "Next Update:" | cut -d ':' -f 2-`
-        CURR_EXP_EPOCH=`date --date="${CURR_EXP}" +%s`
+        CURR_EXP=$($OPENSSL_BIN ocsp -respin "${CERT}".ocsp -text -noverify | grep "Next Update:" | cut -d ':' -f 2-)
+        CURR_EXP_EPOCH=$(date --date="${CURR_EXP}" +%s)
 
         if [ $? -ne 0 ]; then
             Error 3 "can't parse Next Update from current OCSP response"
         fi
 
-        if [ "${CURR_EXP_EPOCH}" -lt `date +%s` ]; then
+        if [ "${CURR_EXP_EPOCH}" -lt $(date +%s) ]; then
             Debug "Current OCSP response expiration: ${CURR_EXP} - expired"
             LogError "current OCSP response is expired: please consider running this script more frequently"
         else
@@ -332,7 +332,7 @@ fi
 
 # get OCSP server URL
 if [ -z "${OCSP_URL}" ]; then
-    OCSP_URL="`$OPENSSL_BIN x509 -in "${TMP}"/ee.pem -ocsp_uri -noout`"
+    OCSP_URL="$($OPENSSL_BIN x509 -in "${TMP}"/ee.pem -ocsp_uri -noout)"
 
     if [ $? -ne 0 ]; then
         Error 1 "can't obtain OCSP server URL from ${CERT}"
@@ -356,7 +356,7 @@ fi
 
 # get OCSP server URL host name
 if [ -z "$OCSP_HOST" ]; then
-    OCSP_HOST="`echo "${OCSP_URL}" | egrep -i "(http://|https://)" | cut -d'/' -f 3`"
+    OCSP_HOST="$(echo "${OCSP_URL}" | egrep -i "(http://|https://)" | cut -d'/' -f 3)"
 
     if [ $? -ne 0 ] || [ -z "$OCSP_HOST" ]; then
         Error 3 "can't extract hostname from OCSP server URL ${OCSP_URL}"
@@ -383,7 +383,7 @@ else
     Debug "Extracting chain from certificates bundle"
 
     # get EE certificate's fingerprint
-    FP_EE="`$OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/ee.pem`"
+    FP_EE="$($OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/ee.pem)"
 
     if [ $? -ne 0 ] || [ -z "$FP_EE" ]; then
         Error 1 "can't obtain EE certificate's fingerprint"
@@ -392,11 +392,11 @@ else
     Debug "EE certificate's fingerprint: $FP_EE"
 
     # get BEGIN CERTIFICATE and END CERTIFICATE separators
-    PEM_BEGIN_CERT="`head "${TMP}"/ee.pem -n 1`"
-    PEM_END_CERT="`tail "${TMP}"/ee.pem -n 1`"
+    PEM_BEGIN_CERT="$(head "${TMP}"/ee.pem -n 1)"
+    PEM_END_CERT="$(tail "${TMP}"/ee.pem -n 1)"
 
     # get number of certificates in the bundle file
-    NUM_OF_CERTS=`cat "${CERT}" | grep -e "$PEM_BEGIN_CERT" | wc -l`
+    NUM_OF_CERTS=$(cat "${CERT}" | grep -e "$PEM_BEGIN_CERT" | wc -l)
 
     if [ $NUM_OF_CERTS -le 1 ]; then
         Error 3 "can't obtain the number of certificates in the chain"
@@ -415,10 +415,10 @@ else
 
     # for each certificate that is extracted from the bundle check if 
     # it's the EE certificate, otherwise uses it to build the chain file
-    for c in `seq 1 $NUM_OF_CERTS`;
+    for c in $(seq 1 $NUM_OF_CERTS);
     do
         # check fingerprint of current and EE certificates
-        FP=`$OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/chain-"${c}".pem`
+        FP=$($OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/chain-"${c}".pem)
         if [ $? -ne 0 ] || [ -z "$FP" ]; then
             Error 1 "can't obtain the fingerprint of the certificate n. ${c} in the bundle"
         else
@@ -450,7 +450,7 @@ fi
 
 # query the OCSP server and save its response
 
-OPENSSL_VERSION=`$OPENSSL_BIN version | sed -rn 's/^OpenSSL\s([0-9]\.[0-9]).*/\1/p'`
+OPENSSL_VERSION=$($OPENSSL_BIN version | sed -rn 's/^OpenSSL\s([0-9]\.[0-9]).*/\1/p')
 
 case $OPENSSL_VERSION in
         '0.9')
@@ -495,7 +495,7 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ $VERIFY -eq 1 ]; then
-    Debug "OCSP response verification results: `cat "${TMP}"/ocsp-verify.txt`"
+    Debug "OCSP response verification results: $(cat "${TMP}"/ocsp-verify.txt)"
 
     cat "${TMP}"/ocsp-verify.txt | grep "Response verify OK" &>>"${TMP}"/log
 
@@ -510,7 +510,7 @@ if [ $VERIFY -eq 1 ]; then
     fi
 fi
 
-Debug "OCSP response: `cat "${TMP}"/ocsp.txt`"
+Debug "OCSP response: $(cat "${TMP}"/ocsp.txt)"
 
 if [ $GOOD_ONLY -eq 1 ]; then
     cat "${TMP}"/ocsp.txt | head -n 1 | grep ": good" &>>"${TMP}"/log
@@ -561,7 +561,7 @@ if [ ${DEBUG} -eq 0 ]; then
             # update haproxy via local UNIX socket
             Debug "Updating haproxy."
 
-            echo "set ssl ocsp-response `base64 -w 0 "${TMP}"/ocsp.der`" | $SOCAT_BIN stdio $HAPROXY_ADMIN_SOCKET &>>"${TMP}"/log
+            echo "set ssl ocsp-response $(base64 -w 0 "${TMP}"/ocsp.der)" | $SOCAT_BIN stdio $HAPROXY_ADMIN_SOCKET &>>"${TMP}"/log
 
             if [ $? -ne 0 ]; then
                 Error 5 "can't update haproxy ssl ocsp-response using $HAPROXY_ADMIN_SOCKET socket"

--- a/hapos-upd
+++ b/hapos-upd
@@ -302,17 +302,17 @@ if [ -e "${CERT}".ocsp ]; then
 
     if [ $? -eq 0 ]; then
         CURR_EXP=`$OPENSSL_BIN ocsp -respin "${CERT}".ocsp -text -noverify | grep "Next Update:" | cut -d ':' -f 2-`
-        CURR_EXP_EPOCH=`date --date="$CURR_EXP" +%s`
+        CURR_EXP_EPOCH=`date --date="${CURR_EXP}" +%s`
 
         if [ $? -ne 0 ]; then
             Error 3 "can't parse Next Update from current OCSP response"
         fi
 
-        if [ $CURR_EXP_EPOCH -lt `date +%s` ]; then
-            Debug "Current OCSP response expiration: $CURR_EXP - expired"
+        if [ "${CURR_EXP_EPOCH}" -lt `date +%s` ]; then
+            Debug "Current OCSP response expiration: ${CURR_EXP} - expired"
             LogError "current OCSP response is expired: please consider running this script more frequently"
         else
-            Debug "Current OCSP response expiration: $CURR_EXP - NOT expired"
+            Debug "Current OCSP response expiration: ${CURR_EXP} - NOT expired"
         fi
     fi
 fi

--- a/hapos-upd
+++ b/hapos-upd
@@ -341,13 +341,13 @@ else
 fi
 
 # check OCSP server URL format (http:// or https://)
-if ! echo "${OCSP_URL}" | egrep -i "(http://|https://)" &>/dev/null ; then
+if ! echo "${OCSP_URL}" | grep -Ei "(http://|https://)" &>/dev/null ; then
     Error 3 "OCSP server URL not in http[s]:// format"
 fi
 
 # get OCSP server URL host name
 if [ -z "$OCSP_HOST" ]; then
-    if ! OCSP_HOST="$(echo "${OCSP_URL}" | egrep -i "(http://|https://)" | cut -d'/' -f 3)" ; then
+    if ! OCSP_HOST="$(echo "${OCSP_URL}" | grep -Ei "(http://|https://)" | cut -d'/' -f 3)" ; then
         Error 3 "can't extract hostname from OCSP server URL ${OCSP_URL}"
     fi
 

--- a/hapos-upd
+++ b/hapos-upd
@@ -34,8 +34,8 @@ PARTIAL_CHAIN=""
 
 function Quit() {
     if [ $KEEP_TEMP -eq 0 ]; then
-        if [ -n "$TMP" ]; then
-            rm -r $TMP &>/dev/null
+        if [ -n "${TMP}" ]; then
+            rm -r "${TMP}" &>/dev/null
         fi
     fi
     exit $1
@@ -50,7 +50,7 @@ function LogError() {
         logger -p "$SYSLOG_PRIO" -s -- "$PROGNAME - $MSG"
     fi
 
-    echo "$MSG" >>$TMP/log
+    echo "$MSG" >>"${TMP}"/log
 }
 
 function Error() {
@@ -73,7 +73,7 @@ function Debug() {
     if [ $DEBUG -eq 1 ]; then
         echo "$1"
     fi
-    echo "$1" >>$TMP/log
+    echo "$1" >>"${TMP}"/log
 }
 
 function Trap() {
@@ -243,7 +243,7 @@ do
             fi
             VAFILE="$2"
             if [ "$VAFILE" == "-" ]; then
-                VAFILE="$TMP/chain.pem"
+                VAFILE="${TMP}/chain.pem"
             else
                 if [ ! -e "$VAFILE" ]; then
                     Error 9 "VAfile does not exists: $VAFILE"
@@ -271,15 +271,15 @@ do
     shift
 done
 
-Debug "Temporary directory: $TMP"
+Debug "Temporary directory: ${TMP}"
 
-$OPENSSL_BIN version | grep OpenSSL &>>$TMP/log
+$OPENSSL_BIN version | grep OpenSSL &>>"${TMP}"/log
 
 if [ $? -ne 0 ]; then
     Error 9 "openssl binary not found; adjust OPENSSL_BIN variable in the script"
 fi
 
-$SOCAT_BIN -V | grep socat &>>$TMP/log
+$SOCAT_BIN -V | grep socat &>>"${TMP}"/log
 
 if [ $? -ne 0 ]; then
     Error 9 "socat binary not found; adjust SOCAT_BIN variable in the script"
@@ -298,7 +298,7 @@ if [ -e $CERT.ocsp ]; then
     Debug "An OCSP response already exists: checking its expiration."
 
     $OPENSSL_BIN ocsp -respin $CERT.ocsp -text -noverify | \
-        grep "Next Update:" &>>$TMP/log
+        grep "Next Update:" &>>"${TMP}"/log
 
     if [ $? -eq 0 ]; then
         CURR_EXP=`$OPENSSL_BIN ocsp -respin $CERT.ocsp -text -noverify | grep "Next Update:" | cut -d ':' -f 2-`
@@ -321,7 +321,7 @@ fi
 # ----------------------------------
 
 # extract EE certificate
-$OPENSSL_BIN x509 -in $CERT -outform PEM -out $TMP/ee.pem &>>$TMP/log
+$OPENSSL_BIN x509 -in $CERT -outform PEM -out "${TMP}"/ee.pem &>>"${TMP}"/log
 
 if [ $? -ne 0 ]; then
     Error 1 "can't extract EE certificate from $CERT"
@@ -329,7 +329,7 @@ fi
 
 # get OCSP server URL
 if [ -z "$OCSP_URL" ]; then
-    OCSP_URL="`$OPENSSL_BIN x509 -in $TMP/ee.pem -ocsp_uri -noout`"
+    OCSP_URL="`$OPENSSL_BIN x509 -in "${TMP}"/ee.pem -ocsp_uri -noout`"
 
     if [ $? -ne 0 ]; then
         Error 1 "can't obtain OCSP server URL from $CERT"
@@ -371,7 +371,7 @@ if [ -e $CERT.issuer ]; then
     Debug "Using existing chain ($CERT.issuer)"
 
     # copy .issuer file to temporary chain.pem
-    cp $CERT.issuer $TMP/chain.pem &>>$TMP/log
+    cp $CERT.issuer "${TMP}"/chain.pem &>>"${TMP}"/log
 
     if [ $? -ne 0 ]; then
         Error 3 "can't copy current chain from $CERT.issuer"
@@ -380,7 +380,7 @@ else
     Debug "Extracting chain from certificates bundle"
 
     # get EE certificate's fingerprint
-    FP_EE="`$OPENSSL_BIN x509 -fingerprint -noout -in $TMP/ee.pem`"
+    FP_EE="`$OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/ee.pem`"
 
     if [ $? -ne 0 -o -z "$FP_EE" ]; then
         Error 1 "can't obtain EE certificate's fingerprint"
@@ -389,8 +389,8 @@ else
     Debug "EE certificate's fingerprint: $FP_EE"
 
     # get BEGIN CERTIFICATE and END CERTIFICATE separators
-    PEM_BEGIN_CERT="`head $TMP/ee.pem -n 1`"
-    PEM_END_CERT="`tail $TMP/ee.pem -n 1`"
+    PEM_BEGIN_CERT="`head "${TMP}"/ee.pem -n 1`"
+    PEM_END_CERT="`tail "${TMP}"/ee.pem -n 1`"
 
     # get number of certificates in the bundle file
     NUM_OF_CERTS=`cat $CERT | grep -e "$PEM_BEGIN_CERT" | wc -l`
@@ -401,10 +401,10 @@ else
 
     Debug "$NUM_OF_CERTS certificates found in the bundle"
 
-    # save each certificate in the bundle into $TMP/chain-X.pem 
+    # save each certificate in the bundle into "${TMP}"/chain-X.pem 
     cat $CERT | \
         sed -n -e "/$PEM_BEGIN_CERT/,/$PEM_END_CERT/p" | \
-        awk "/$PEM_BEGIN_CERT/{x=\"$TMP/chain-\" ++i \".pem\";}{print > x;}" &>>$TMP/log
+        awk "/$PEM_BEGIN_CERT/{x=\"${TMP}/chain-\" ++i \".pem\";}{print > x;}" &>>"${TMP}"/log
 
     if [ $? -ne 0 ]; then
         Error 3 "can't extract certificates from bundle"
@@ -415,7 +415,7 @@ else
     for c in `seq 1 $NUM_OF_CERTS`;
     do
         # check fingerprint of current and EE certificates
-        FP="`$OPENSSL_BIN x509 -fingerprint -noout -in $TMP/chain-$c.pem`"
+        FP="`$OPENSSL_BIN x509 -fingerprint -noout -in "${TMP}"/chain-$c.pem`"
         if [ $? -ne 0 -o -z "$FP" ]; then
             Error 1 "can't obtain the fingerprint of the certificate n. $c in the bundle"
         else
@@ -423,7 +423,7 @@ else
                 Debug "Bundle certificate n. $c fingerprint: $FP - it's part of the chain"
 
                 # current certificate is not the same as the EE; append to the chain
-                cat $TMP/chain-$c.pem >> $TMP/chain.pem
+                cat "${TMP}"/chain-$c.pem >> "${TMP}"/chain.pem
             else
                 Debug "Bundle certificate n. $c fingerprint: $FP - EE certificate"
             fi
@@ -432,7 +432,7 @@ else
 fi
 
 # check if the EE certificate validates against the chain
-$OPENSSL_BIN verify $PARTIAL_CHAIN -CAfile $TMP/chain.pem $TMP/ee.pem &>>$TMP/log
+$OPENSSL_BIN verify $PARTIAL_CHAIN -CAfile "${TMP}"/chain.pem "${TMP}"/ee.pem &>>"${TMP}"/log
 
 if [ $? -ne 0 ]; then
     if [ -e $CERT.issuer ]; then
@@ -451,19 +451,19 @@ OPENSSL_VERSION=`$OPENSSL_BIN version | sed -rn 's/^OpenSSL\s([0-9]\.[0-9]).*/\1
 
 case $OPENSSL_VERSION in
         '0.9')
-                $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer $TMP/chain.pem -cert $TMP/ee.pem \
-                        -respout $TMP/ocsp.der -noverify \
-                        -no_nonce -url $OCSP_URL -header "Host=$OCSP_HOST" &>>$TMP/log
+                $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
+                        -respout "${TMP}"/ocsp.der -noverify \
+                        -no_nonce -url $OCSP_URL -header "Host=$OCSP_HOST" &>>"${TMP}"/log
                 ;;
         '1.0')
-                $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer $TMP/chain.pem -cert $TMP/ee.pem \
-                        -respout $TMP/ocsp.der -noverify \
-                        -no_nonce -url $OCSP_URL -header "Host" "$OCSP_HOST" &>>$TMP/log
+                $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
+                        -respout "${TMP}"/ocsp.der -noverify \
+                        -no_nonce -url $OCSP_URL -header "Host" "$OCSP_HOST" &>>"${TMP}"/log
                 ;;
         *)
-                $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer $TMP/chain.pem -cert $TMP/ee.pem \
-                        -respout $TMP/ocsp.der -noverify \
-                        -no_nonce -url $OCSP_URL &>>$TMP/log
+                $OPENSSL_BIN ocsp $PARTIAL_CHAIN -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
+                        -respout "${TMP}"/ocsp.der -noverify \
+                        -no_nonce -url $OCSP_URL &>>"${TMP}"/log
                 ;;
 esac
 
@@ -477,14 +477,14 @@ if [ $VERIFY -eq 0 ]; then
     VERIFYOPT="-noverify"
 fi
 if [ -z "$VAFILE" ]; then
-    $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer $TMP/chain.pem -cert $TMP/ee.pem \
-        -respin $TMP/ocsp.der -no_nonce -CAfile $TMP/chain.pem \
-        -out $TMP/ocsp.txt &>>$TMP/ocsp-verify.txt
+    $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
+        -respin "${TMP}"/ocsp.der -no_nonce -CAfile "${TMP}"/chain.pem \
+        -out "${TMP}"/ocsp.txt &>>"${TMP}"/ocsp-verify.txt
 else
-    $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer $TMP/chain.pem -cert $TMP/ee.pem \
-        -respin $TMP/ocsp.der -no_nonce -CAfile $TMP/chain.pem \
+    $OPENSSL_BIN ocsp $PARTIAL_CHAIN $VERIFYOPT -issuer "${TMP}"/chain.pem -cert "${TMP}"/ee.pem \
+        -respin "${TMP}"/ocsp.der -no_nonce -CAfile "${TMP}"/chain.pem \
         -VAfile $VAFILE \
-        -out $TMP/ocsp.txt &>>$TMP/ocsp-verify.txt
+        -out "${TMP}"/ocsp.txt &>>"${TMP}"/ocsp-verify.txt
 fi
 
 if [ $? -ne 0 ]; then
@@ -492,12 +492,12 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ $VERIFY -eq 1 ]; then
-    Debug "OCSP response verification results: `cat $TMP/ocsp-verify.txt`"
+    Debug "OCSP response verification results: `cat "${TMP}"/ocsp-verify.txt`"
 
-    cat $TMP/ocsp-verify.txt | grep "Response verify OK" &>>$TMP/log
+    cat "${TMP}"/ocsp-verify.txt | grep "Response verify OK" &>>"${TMP}"/log
 
     if [ $? -ne 0 ]; then
-        grep "signer certificate not found" $TMP/ocsp-verify.txt &>/dev/null
+        grep "signer certificate not found" "${TMP}"/ocsp-verify.txt &>/dev/null
 
         if [ $? -eq 0 ]; then
             Error 4 "OCSP response verification failure: signer certificate not found; try with '--VAfile -' or '--VAfile OCSP-response-signing-certificate-file' arguments"
@@ -507,10 +507,10 @@ if [ $VERIFY -eq 1 ]; then
     fi
 fi
 
-Debug "OCSP response: `cat $TMP/ocsp.txt`"
+Debug "OCSP response: `cat "${TMP}"/ocsp.txt`"
 
 if [ $GOOD_ONLY -eq 1 ]; then
-    cat $TMP/ocsp.txt | head -n 1 | grep ": good" &>>$TMP/log
+    cat "${TMP}"/ocsp.txt | head -n 1 | grep ": good" &>>"${TMP}"/log
 
     if [ $? -ne 0 ]; then
         Error 4 "OCSP response, certificate status not good"
@@ -521,8 +521,8 @@ fi
 # ----------------------------------
 
 # Status:
-#   - $TMP/ocsp.der contains the OCSP response, DER format
-#   - $TMP/ocsp.txt contains the textual OCSP response as produced
+#   - "${TMP}"/ocsp.der contains the OCSP response, DER format
+#   - "${TMP}"/ocsp.txt contains the textual OCSP response as produced
 #       by openssl
 #   - the OCSP response has been verified against the chain or 
 #       the --VAfile
@@ -530,14 +530,14 @@ fi
 if [ $DEBUG -eq 0 ]; then
     # update .ocsp and .issuer files
 
-    cp $TMP/ocsp.der $CERT.ocsp &>>$TMP/log
+    cp "${TMP}"/ocsp.der $CERT.ocsp &>>"${TMP}"/log
 
     if [ $? -ne 0 ]; then
         Error 5 "can't update $CERT.ocsp file"
     fi
 
     if [ ! -e $CERT.issuer ]; then
-        cp $TMP/chain.pem $CERT.issuer &>>$TMP/log
+        cp "${TMP}"/chain.pem $CERT.issuer &>>"${TMP}"/log
 
         if [ $? -ne 0 ]; then
             Error 5 "can't update $CERT.issuer file"
@@ -558,7 +558,7 @@ if [ $DEBUG -eq 0 ]; then
             # update haproxy via local UNIX socket
             Debug "Updating haproxy."
 
-            echo "set ssl ocsp-response `base64 -w 0 $TMP/ocsp.der`" | $SOCAT_BIN stdio $HAPROXY_ADMIN_SOCKET &>>$TMP/log
+            echo "set ssl ocsp-response `base64 -w 0 "${TMP}"/ocsp.der`" | $SOCAT_BIN stdio $HAPROXY_ADMIN_SOCKET &>>"${TMP}"/log
 
             if [ $? -ne 0 ]; then
                 Error 5 "can't update haproxy ssl ocsp-response using $HAPROXY_ADMIN_SOCKET socket"

--- a/hapos-upd
+++ b/hapos-upd
@@ -561,10 +561,10 @@ if [ ${DEBUG} -eq 0 ]; then
             # update haproxy via local UNIX socket
             Debug "Updating haproxy."
 
-            echo "set ssl ocsp-response $(base64 -w 0 "${TMP}"/ocsp.der)" | $SOCAT_BIN stdio $HAPROXY_ADMIN_SOCKET &>>"${TMP}"/log
+            echo "set ssl ocsp-response $(base64 -w 0 "${TMP}"/ocsp.der)" | $SOCAT_BIN stdio "${HAPROXY_ADMIN_SOCKET}" &>>"${TMP}"/log
 
             if [ $? -ne 0 ]; then
-                Error 5 "can't update haproxy ssl ocsp-response using $HAPROXY_ADMIN_SOCKET socket"
+                Error 5 "can't update haproxy ssl ocsp-response using ${HAPROXY_ADMIN_SOCKET} socket"
             fi
         fi
     else

--- a/hapos-upd
+++ b/hapos-upd
@@ -11,7 +11,7 @@ VERSION="0.4.1-pre1"
 
 PROGNAME="hapos-upd"
 
-if [ -z ${OPENSSL_BIN+x} ]; then
+if [ -z "${OPENSSL_BIN+x}" ]; then
     OPENSSL_BIN="openssl"
 fi
 

--- a/hapos-upd
+++ b/hapos-upd
@@ -382,7 +382,7 @@ else
     PEM_END_CERT="$(tail "${TMP}"/ee.pem -n 1)"
 
     # get number of certificates in the bundle file
-    NUM_OF_CERTS=$(cat "${CERT}" | grep -ce "$PEM_BEGIN_CERT")
+    NUM_OF_CERTS=$(grep -ce "$PEM_BEGIN_CERT" < "${CERT}")
 
     # shellcheck disable=SC2086
     if [ $NUM_OF_CERTS -le 1 ]; then
@@ -475,8 +475,7 @@ fi
 if [ $VERIFY -eq 1 ]; then
     Debug "OCSP response verification results: $(cat "${TMP}"/ocsp-verify.txt)"
 
-    if ! cat "${TMP}"/ocsp-verify.txt |
-            grep "Response verify OK" &>>"${TMP}"/log ; then
+    if ! grep < "${TMP}"/ocsp-verify.txt "Response verify OK" &>>"${TMP}"/log ; then
         if grep "signer certificate not found" \
                 "${TMP}"/ocsp-verify.txt &>/dev/null ; then
             Error 4 "OCSP response verification failure: signer certificate not found; try with '--VAfile -' or '--VAfile OCSP-response-signing-certificate-file' arguments"
@@ -489,7 +488,7 @@ fi
 Debug "OCSP response: $(cat "${TMP}"/ocsp.txt)"
 
 if [ $GOOD_ONLY -eq 1 ]; then
-    if ! cat "${TMP}"/ocsp.txt | head -n 1 | grep ": good" &>>"${TMP}"/log ; then
+    if ! head -n 1 "${TMP}"/ocsp.txt | grep ": good" &>>"${TMP}"/log ; then
         Error 4 "OCSP response, certificate status not good"
     fi
 fi

--- a/hapos-upd
+++ b/hapos-upd
@@ -176,7 +176,7 @@ TMP="`mktemp -d -q -t $PROGNAME.XXXXXXXXXX`"
 # COMMAND LINE PROCESSING
 # ----------------------------------
 
-while [[ $# > 0 ]]
+while [[ $# -gt 0 ]]
 do
 
     case "$1" in

--- a/hapos-upd
+++ b/hapos-upd
@@ -396,7 +396,7 @@ else
     PEM_END_CERT="$(tail "${TMP}"/ee.pem -n 1)"
 
     # get number of certificates in the bundle file
-    NUM_OF_CERTS=$(cat "${CERT}" | grep -e "$PEM_BEGIN_CERT" | wc -l)
+    NUM_OF_CERTS=$(cat "${CERT}" | grep -ce "$PEM_BEGIN_CERT")
 
     if [ $NUM_OF_CERTS -le 1 ]; then
         Error 3 "can't obtain the number of certificates in the chain"

--- a/hapos-upd
+++ b/hapos-upd
@@ -57,7 +57,7 @@ function Error() {
     if [ $1 -eq 9 ]; then
         MSG="Error: $2"
     else
-        MSG="Error processing '$CERT': $2"
+        MSG="Error processing '${CERT}': $2"
     fi
 
     LogError "$MSG"
@@ -285,7 +285,7 @@ if [ $? -ne 0 ]; then
     Error 9 "socat binary not found; adjust SOCAT_BIN variable in the script"
 fi
 
-if [ -z "$CERT" ]; then
+if [ -z "${CERT}" ]; then
     Error 9 "certificate not provided (--cert argument)"
 fi
 
@@ -293,15 +293,15 @@ fi
 # ----------------------------------
 
 ISNEW=1
-if [ -e $CERT.ocsp ]; then
+if [ -e "${CERT}".ocsp ]; then
     ISNEW=0
     Debug "An OCSP response already exists: checking its expiration."
 
-    $OPENSSL_BIN ocsp -respin $CERT.ocsp -text -noverify | \
+    $OPENSSL_BIN ocsp -respin "${CERT}".ocsp -text -noverify | \
         grep "Next Update:" &>>"${TMP}"/log
 
     if [ $? -eq 0 ]; then
-        CURR_EXP=`$OPENSSL_BIN ocsp -respin $CERT.ocsp -text -noverify | grep "Next Update:" | cut -d ':' -f 2-`
+        CURR_EXP=`$OPENSSL_BIN ocsp -respin "${CERT}".ocsp -text -noverify | grep "Next Update:" | cut -d ':' -f 2-`
         CURR_EXP_EPOCH=`date --date="$CURR_EXP" +%s`
 
         if [ $? -ne 0 ]; then
@@ -321,10 +321,10 @@ fi
 # ----------------------------------
 
 # extract EE certificate
-$OPENSSL_BIN x509 -in $CERT -outform PEM -out "${TMP}"/ee.pem &>>"${TMP}"/log
+$OPENSSL_BIN x509 -in "${CERT}" -outform PEM -out "${TMP}"/ee.pem &>>"${TMP}"/log
 
 if [ $? -ne 0 ]; then
-    Error 1 "can't extract EE certificate from $CERT"
+    Error 1 "can't extract EE certificate from ${CERT}"
 fi
 
 # get OCSP server URL
@@ -332,7 +332,7 @@ if [ -z "${OCSP_URL}" ]; then
     OCSP_URL="`$OPENSSL_BIN x509 -in "${TMP}"/ee.pem -ocsp_uri -noout`"
 
     if [ $? -ne 0 ]; then
-        Error 1 "can't obtain OCSP server URL from $CERT"
+        Error 1 "can't obtain OCSP server URL from ${CERT}"
     fi
 
     if [ -z "${OCSP_URL}" ]; then
@@ -367,14 +367,14 @@ fi
 # EXTRACT CHAIN INFO
 # ----------------------------------
 
-if [ -e $CERT.issuer ]; then
-    Debug "Using existing chain ($CERT.issuer)"
+if [ -e "${CERT}".issuer ]; then
+    Debug "Using existing chain (${CERT}.issuer)"
 
     # copy .issuer file to temporary chain.pem
-    cp $CERT.issuer "${TMP}"/chain.pem &>>"${TMP}"/log
+    cp "${CERT}".issuer "${TMP}"/chain.pem &>>"${TMP}"/log
 
     if [ $? -ne 0 ]; then
-        Error 3 "can't copy current chain from $CERT.issuer"
+        Error 3 "can't copy current chain from ${CERT}.issuer"
     fi
 else
     Debug "Extracting chain from certificates bundle"
@@ -393,7 +393,7 @@ else
     PEM_END_CERT="`tail "${TMP}"/ee.pem -n 1`"
 
     # get number of certificates in the bundle file
-    NUM_OF_CERTS=`cat $CERT | grep -e "$PEM_BEGIN_CERT" | wc -l`
+    NUM_OF_CERTS=`cat "${CERT}" | grep -e "$PEM_BEGIN_CERT" | wc -l`
 
     if [ $NUM_OF_CERTS -le 1 ]; then
         Error 3 "can't obtain the number of certificates in the chain"
@@ -402,7 +402,7 @@ else
     Debug "$NUM_OF_CERTS certificates found in the bundle"
 
     # save each certificate in the bundle into "${TMP}"/chain-X.pem 
-    cat $CERT | \
+    cat "${CERT}" | \
         sed -n -e "/$PEM_BEGIN_CERT/,/$PEM_END_CERT/p" | \
         awk "/$PEM_BEGIN_CERT/{x=\"${TMP}/chain-\" ++i \".pem\";}{print > x;}" &>>"${TMP}"/log
 
@@ -435,8 +435,8 @@ fi
 $OPENSSL_BIN verify $PARTIAL_CHAIN -CAfile "${TMP}"/chain.pem "${TMP}"/ee.pem &>>"${TMP}"/log
 
 if [ $? -ne 0 ]; then
-    if [ -e $CERT.issuer ]; then
-        Error 1 "can't validate the EE certificate against the existing chain; if it has been changed recently consider removing the current $CERT.issuer file and let this script to figure out a new one"
+    if [ -e "${CERT}".issuer ]; then
+        Error 1 "can't validate the EE certificate against the existing chain; if it has been changed recently consider removing the current ${CERT}.issuer file and let this script to figure out a new one"
     else
         Error 1 "can't validate the EE certificate against the extracted chain"
     fi
@@ -530,17 +530,17 @@ fi
 if [ $DEBUG -eq 0 ]; then
     # update .ocsp and .issuer files
 
-    cp "${TMP}"/ocsp.der $CERT.ocsp &>>"${TMP}"/log
+    cp "${TMP}"/ocsp.der "${CERT}".ocsp &>>"${TMP}"/log
 
     if [ $? -ne 0 ]; then
-        Error 5 "can't update $CERT.ocsp file"
+        Error 5 "can't update ${CERT}.ocsp file"
     fi
 
-    if [ ! -e $CERT.issuer ]; then
-        cp "${TMP}"/chain.pem $CERT.issuer &>>"${TMP}"/log
+    if [ ! -e "${CERT}".issuer ]; then
+        cp "${TMP}"/chain.pem "${CERT}".issuer &>>"${TMP}"/log
 
         if [ $? -ne 0 ]; then
-            Error 5 "can't update $CERT.issuer file"
+            Error 5 "can't update ${CERT}.issuer file"
         fi
     fi
 

--- a/hapos-upd
+++ b/hapos-upd
@@ -33,12 +33,13 @@ SKIP_UPDATE=0
 PARTIAL_CHAIN=""
 
 function Quit() {
+    local -i err=$1
     if [ $KEEP_TEMP -eq 0 ]; then
         if [ -n "${TMP}" ]; then
             rm -r "${TMP}" &>/dev/null
         fi
     fi
-    exit $1
+    exit ${err}
 }
 
 function LogError() {
@@ -54,7 +55,9 @@ function LogError() {
 }
 
 function Error() {
-    if [ $1 -eq 9 ]; then
+    local -i err=$1
+
+    if [ ${err} -eq 9 ]; then
         MSG="Error: $2"
     else
         MSG="Error processing '${CERT}': $2"
@@ -62,11 +65,11 @@ function Error() {
 
     LogError "$MSG"
 
-    if [ $1 -eq 9 ]; then
+    if [ ${err} -eq 9 ]; then
         echo "Run $PROGNAME -h for help" >&2
     fi
 
-    Quit $1
+    Quit ${err}
 }
 
 function Debug() {

--- a/hapos-upd
+++ b/hapos-upd
@@ -7,7 +7,7 @@
 
 set -o nounset
 
-VERSION="0.4.1-pre1"
+VERSION="0.5.0"
 
 PROGNAME="hapos-upd"
 
@@ -378,8 +378,8 @@ else
     Debug "EE certificate's fingerprint: $FP_EE"
 
     # get BEGIN CERTIFICATE and END CERTIFICATE separators
-    PEM_BEGIN_CERT="$(head "${TMP}"/ee.pem -n 1)"
-    PEM_END_CERT="$(tail "${TMP}"/ee.pem -n 1)"
+    PEM_BEGIN_CERT="$(head -n 1 "${TMP}"/ee.pem)"
+    PEM_END_CERT="$(tail -n 1 "${TMP}"/ee.pem)"
 
     # get number of certificates in the bundle file
     NUM_OF_CERTS=$(grep -ce "$PEM_BEGIN_CERT" < "${CERT}")
@@ -528,7 +528,7 @@ if [ ${DEBUG} -eq 0 ]; then
             # update haproxy via local UNIX socket
             Debug "Updating haproxy."
 
-            if ! echo "set ssl ocsp-response $(base64 -w 0 "${TMP}"/ocsp.der)" |
+            if ! echo "set ssl ocsp-response $($OPENSSL_BIN enc -base64 -A -in "$TMP"/ocsp.der)" |
 		    $SOCAT_BIN stdio "${HAPROXY_ADMIN_SOCKET}" &>>"${TMP}"/log ; then
                 Error 5 "can't update haproxy ssl ocsp-response using ${HAPROXY_ADMIN_SOCKET} socket"
             fi


### PR DESCRIPTION
Otherwise file names with special chars might cause shell expansion.
In the worst case the program could write to wrong files.

The variables $PARTIAL_CHAIN and $VERIFYOPT cannot be quoted, as they are optional.

My certificates are called like '\*.example.com.pem'.
The program worked flawlessly until I added another file in that directory '\*.foo.example.com.pem'.
The program then performed shell file name expansion, as many variables were not properly quoted.

File names containing spaces would probably also mess up the current version of the program.
